### PR TITLE
Fix refmap name not matching exactly

### DIFF
--- a/src/main/resources/variablespawnerhardness.mixins.json
+++ b/src/main/resources/variablespawnerhardness.mixins.json
@@ -2,7 +2,6 @@
   "package": "ga.ozli.minecraftmods.variablespawnerhardness.mixin",
   "required": true,
   "compatibilityLevel": "JAVA_8",
-  "refmap": "variablespawnerhardness.refmap.json",
   "mixins": [
     "AbstractBlockStateMixin"
   ],


### PR DESCRIPTION
Fixes https://github.com/PaintNinja/VariableSpawnerHardness/issues/2.

The `refmap` entry is generated automatically when building, so deleting the entry will make sure it's always correct.